### PR TITLE
Use private ACL as default when uploading to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The following settings must be passed as environment variables as shown in the e
 | `source_file_path`         | ✔️        | -             | The local file you wish to upload to S3. |
 | `destination_file_path`    | ✔️        | -             | The destination path in S3 |
 | `aws_region`               | -        | `eu-west-1`   | The AWS region of the bucket. |
-| `acl`                      | -        | `public-read` | The Access Control List of the uploaded object. |
+| `acl`                      | -        | `private` | The Access Control List of the uploaded object. |

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
   acl:
     description: 'access control list'
-    default: 'public-read'
+    default: 'private'
     required: false
   source_file_path:
     required: true


### PR DESCRIPTION
Since buckets will be private, uploading objects with public ACL will result in an error
